### PR TITLE
Command line parameters for AZP agent config script

### DIFF
--- a/agent.tf
+++ b/agent.tf
@@ -60,12 +60,7 @@ resource "google_compute_instance" "default" {
 
       # run the actual agent
       "cd agent",
-      "export VSTS_AGENT_INPUT_URL=https://dev.azure.com/${var.pipelines_org}",
-      "export VSTS_AGENT_INPUT_AUTH=pat",
-      "export VSTS_AGENT_INPUT_TOKEN=${var.pipelines_agent_pat}",
-      "export VSTS_AGENT_INPUT_POOL=${var.pipelines_pool_name}",
-      "export VSTS_AGENT_INPUT_AGENT=${var.agent_name}",
-      "./config.sh --unattended --acceptTeeEula --replace",
+      "./config.sh --unattended --acceptTeeEula --replace --url https://dev.azure.com/${var.pipelines_org} --auth pat --token ${var.pipelines_agent_pat} --pool ${var.pipelines_pool_name} --agent ${var.agent_name}",
       "sudo ./svc.sh install",
       "sudo ./svc.sh start",
     ]
@@ -78,12 +73,7 @@ resource "google_compute_instance" "default" {
       "cd ~/agent",
       "sudo ./svc.sh stop",
       "sudo ./svc.sh uninstall",
-      "export VSTS_AGENT_INPUT_URL=https://dev.azure.com/${var.pipelines_org}",
-      "export VSTS_AGENT_INPUT_AUTH=pat",
-      "export VSTS_AGENT_INPUT_TOKEN=${var.pipelines_agent_pat}",
-      "export VSTS_AGENT_INPUT_POOL=${var.pipelines_pool_name}",
-      "export VSTS_AGENT_INPUT_AGENT=${var.agent_name}",
-      "./config.sh remove",
+      "./config.sh remove --url https://dev.azure.com/${var.pipelines_org} --auth pat --token ${var.pipelines_agent_pat} --pool ${var.pipelines_pool_name} --agent ${var.agent_name}",
     ]
   }
 }

--- a/agent.tf
+++ b/agent.tf
@@ -60,7 +60,8 @@ resource "google_compute_instance" "default" {
 
       # run the actual agent
       "cd agent",
-      "./config.sh --unattended --acceptTeeEula --replace --url https://dev.azure.com/${var.pipelines_org} --auth pat --token ${var.pipelines_agent_pat} --pool ${var.pipelines_pool_name} --agent ${var.agent_name}",
+      "export VSTS_AGENT_INPUT_TOKEN=${var.pipelines_agent_pat}",
+      "./config.sh --unattended --acceptTeeEula --replace --url https://dev.azure.com/${var.pipelines_org} --auth pat --pool ${var.pipelines_pool_name} --agent ${var.agent_name}",
       "sudo ./svc.sh install",
       "sudo ./svc.sh start",
     ]
@@ -73,7 +74,8 @@ resource "google_compute_instance" "default" {
       "cd ~/agent",
       "sudo ./svc.sh stop",
       "sudo ./svc.sh uninstall",
-      "./config.sh remove --url https://dev.azure.com/${var.pipelines_org} --auth pat --token ${var.pipelines_agent_pat} --pool ${var.pipelines_pool_name} --agent ${var.agent_name}",
+      "export VSTS_AGENT_INPUT_TOKEN=${var.pipelines_agent_pat}",
+      "./config.sh remove --url https://dev.azure.com/${var.pipelines_org} --auth pat --pool ${var.pipelines_pool_name} --agent ${var.agent_name}",
     ]
   }
 }


### PR DESCRIPTION
Use command line parameters instead of environment variables for the Azure Pipelines agent configuration script, as documented in:

https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/v2-linux?view=azure-devops

Addresses GitHub issue https://github.com/g3rv4/terraform-pipeline-agent/issues/1

Please note that although I was able to test this manually and the script will register /
unregister the agent against an existing AZP project, I was not able to test the entire system.

Signed-off-by: Jean-Francois Panisset <panisset@gmail.com>